### PR TITLE
Ensure API_HOST is set correctly when npm run build is executed

### DIFF
--- a/add_pwd_host.sh
+++ b/add_pwd_host.sh
@@ -5,4 +5,4 @@ hostname=$(echo $host_ip | sed 's/\./-/g')
 FQDN=${PWD_HOST_FQDN}
 API_ENDPOINT="pwd$hostname-8080.$FQDN"
   
-sed -i "2i ENV API_HOST=${API_ENDPOINT}" ./react-client/Dockerfile
+sed -i -e "s/localhost/${API_ENDPOINT}/" ./react-client/package.json

--- a/react-client/package.json
+++ b/react-client/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "NODE_ENV=production ./node_modules/.bin/http-server -p 3000 src/static",
-    "build": "NODE_ENV=production ./node_modules/.bin/webpack --color -p --progress"
+    "start": "./node_modules/.bin/http-server -p 3000 src/static",
+    "build": "set NODE_ENV=production&& API_HOST=localhost ./node_modules/.bin/webpack --color -p --progress"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
Environment variables either need to be set using something like the `dotenv` package or by inlining them within the script in the `package.json`.  This PR updates the `add_pwd_host.sh` script to update the `package.json` file with the correct API_HOST.