### PR TITLE
Dynamic api host

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,5 @@ git clone https://github.com/dockersamples/javaee-demo.git
 
 cd javaee-demo
 
-./add_pwd_host.sh
-
 docker-compose up
 ```

--- a/add_pwd_host.sh
+++ b/add_pwd_host.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-host_ip=$(hostname -i)
-hostname=$(echo $host_ip | sed 's/\./-/g')
-FQDN=${PWD_HOST_FQDN}
-API_ENDPOINT="pwd$hostname-8080.$FQDN"
-  
-sed -i "2i ENV API_HOST=${API_ENDPOINT}" ./react-client/Dockerfile

--- a/react-client/src/api-host.js
+++ b/react-client/src/api-host.js
@@ -1,0 +1,6 @@
+
+const isPwdHost = window.location.host.indexOf("pwd") === 0;
+
+export const API_HOST = (isPwdHost) ?
+    window.location.host.replace("-80.host", "-8080.host") : 
+    window.location.host + ":8080";

--- a/react-client/src/components/IndexPage.js
+++ b/react-client/src/components/IndexPage.js
@@ -2,11 +2,9 @@
 import React from 'react';
 import MoviePreview from './MoviePreview';
 import MoviePage from './MoviePage';
+import { API_HOST } from '../api-host';
 
-var APPLICATION_HOST = process.env.API_HOST; 
-var REQUEST_URL = "http://"; 
-REQUEST_URL += APPLICATION_HOST;
-REQUEST_URL += '/movieplex7-1.0-SNAPSHOT/webresources/movie/';
+var REQUEST_URL = `http://${API_HOST}/movieplex7-1.0-SNAPSHOT/webresources/movie/`;
 var parseXml = require('xmljson').to_json;
 
 console.log(process.env);

--- a/react-client/src/components/MoviePage.js
+++ b/react-client/src/components/MoviePage.js
@@ -2,12 +2,9 @@ import React from 'react';
 import { Link } from 'react-router';
 import NotFoundPage from './NotFoundPage';
 import MoviesMenu from './MoviesMenu';
+import { API_HOST } from '../api-host';
 
-var APPLICATION_HOST = process.env.API_HOST; 
-console.log("host: " + process.env.API_HOST);
-var REQUEST_URL = "http://"; 
-REQUEST_URL += APPLICATION_HOST;  
-REQUEST_URL += '/movieplex7-1.0-SNAPSHOT/webresources/movie/';
+var REQUEST_URL = `http://${API_HOST}/movieplex7-1.0-SNAPSHOT/webresources/movie/`;
 var parseXml = require('xmljson').to_json;
 
 function status(response) {  

--- a/react-client/webpack.config.js
+++ b/react-client/webpack.config.js
@@ -24,8 +24,7 @@ module.exports = {
   plugins: [
     new webpack.DefinePlugin({
       'process.env' : {
-        NODE_ENV: JSON.stringify(process.env.NODE_ENV),
-        API_HOST: JSON.stringify(process.env.API_HOST || "localhost:8080")
+        NODE_ENV: JSON.stringify(process.env.NODE_ENV)
       }
     })
   ]


### PR DESCRIPTION
Here's another attempt.  This one no longer relies on an environment variable to define the `API_HOST` and determines it dynamically in the app.  This actually has a few advantages...

- It'll run on PWD without a necessary pre-processing step
- A Docker image built in one environment will work in another environment without needing to be rebuilt

It does make the assumption that the backend API will be available at the same host (with a minor tweak for PWD), but for this application, that's a safe assumption.